### PR TITLE
Add Geocoder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '3.3.0'
 gem 'bootsnap', require: false
 gem 'cssbundling-rails'
 gem 'devise'
+gem 'geocoder'
 gem 'jsbundling-rails'
 gem 'letter_opener_web'
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -110,6 +111,9 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -346,6 +350,7 @@ DEPENDENCIES
   debug
   devise
   faker
+  geocoder
   jsbundling-rails
   letter_opener_web
   omniauth

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,11 +7,15 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
          #:omniauthable, omniauth_providers: [:google_oauth2]
+  geocoded_by :address
 
-  validates :first_name, presence: true, length: { minimum: 2, maximum: 30 }
-  validates :last_name, length: { minimum: 2, maximum: 30 }, allow_blank: true
+  before_validation :set_address
+
+  validates :first_name, :last_name, presence: true, length: { minimum: 2, maximum: 30 }
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validate :password_complexity
+
+  after_validation :geocode, if: -> { address.present? && address_changed? }
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
@@ -23,7 +27,7 @@ class User < ApplicationRecord
   end
 
   private
-  
+
   def password_complexity
     return unless password.present?
 
@@ -33,5 +37,13 @@ class User < ApplicationRecord
     return if password.match?(/[!@#$%^&*]/)
 
     errors.add(:password, 'must contain at least one special character')
+  end
+
+  def set_address
+    self.address = "#{city}, #{country}" if city.present? && country.present?
+  end
+
+  def set_fullname
+    self.full_name = "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,3 @@
+Geocoder.configure(
+  timeout: 60
+)

--- a/db/migrate/20240515033522_add_geocode_attributes_to_user.rb
+++ b/db/migrate/20240515033522_add_geocode_attributes_to_user.rb
@@ -1,0 +1,6 @@
+class AddGeocodeAttributesToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,85 +10,87 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_135712) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_15_033522) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'appointments', force: :cascade do |t|
-    t.date 'date', null: false
-    t.text 'description', null: false
-    t.bigint 'client_id', null: false
-    t.bigint 'freelancer_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['client_id'], name: 'index_appointments_on_client_id'
-    t.index ['freelancer_id'], name: 'index_appointments_on_freelancer_id'
+  create_table "appointments", force: :cascade do |t|
+    t.date "date", null: false
+    t.text "description", null: false
+    t.bigint "client_id", null: false
+    t.bigint "freelancer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_appointments_on_client_id"
+    t.index ["freelancer_id"], name: "index_appointments_on_freelancer_id"
   end
 
-  create_table 'notifications', force: :cascade do |t|
-    t.text 'content'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_notifications_on_user_id'
+  create_table "notifications", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
-  create_table 'reviews', force: :cascade do |t|
-    t.integer 'rating', null: false
-    t.text 'subject'
-    t.bigint 'client_id', null: false
-    t.bigint 'freelancer_id', null: false
-    t.bigint 'service_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['client_id'], name: 'index_reviews_on_client_id'
-    t.index ['freelancer_id'], name: 'index_reviews_on_freelancer_id'
-    t.index ['service_id'], name: 'index_reviews_on_service_id'
+  create_table "reviews", force: :cascade do |t|
+    t.integer "rating", null: false
+    t.text "subject"
+    t.bigint "client_id", null: false
+    t.bigint "freelancer_id", null: false
+    t.bigint "service_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id"], name: "index_reviews_on_client_id"
+    t.index ["freelancer_id"], name: "index_reviews_on_freelancer_id"
+    t.index ["service_id"], name: "index_reviews_on_service_id"
   end
 
-  create_table 'services', force: :cascade do |t|
-    t.string 'title', null: false
-    t.text 'description'
-    t.integer 'price', null: false
-    t.json 'categories', default: []
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_services_on_user_id'
+  create_table "services", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.integer "price", null: false
+    t.json "categories", default: []
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'first_name', default: '', null: false
-    t.string 'last_name', default: ''
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'full_name'
-    t.string 'uid'
-    t.string 'avatar_url'
-    t.string 'provider'
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'freelancer'
-    t.boolean 'client'
-    t.text 'biography'
-    t.json 'skills', default: []
-    t.date 'birthdate'
-    t.string 'address'
-    t.string 'city'
-    t.string 'country'
-    t.string 'mobile'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", force: :cascade do |t|
+    t.string "first_name", default: "", null: false
+    t.string "last_name", default: ""
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "full_name"
+    t.string "uid"
+    t.string "avatar_url"
+    t.string "provider"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "freelancer"
+    t.boolean "client"
+    t.text "biography"
+    t.json "skills", default: []
+    t.date "birthdate"
+    t.string "address"
+    t.string "city"
+    t.string "country"
+    t.string "mobile"
+    t.float "latitude"
+    t.float "longitude"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key 'appointments', 'users', column: 'client_id'
-  add_foreign_key 'appointments', 'users', column: 'freelancer_id'
-  add_foreign_key 'notifications', 'users'
-  add_foreign_key 'reviews', 'services'
-  add_foreign_key 'reviews', 'users', column: 'client_id'
-  add_foreign_key 'reviews', 'users', column: 'freelancer_id'
-  add_foreign_key 'services', 'users'
+  add_foreign_key "appointments", "users", column: "client_id"
+  add_foreign_key "appointments", "users", column: "freelancer_id"
+  add_foreign_key "notifications", "users"
+  add_foreign_key "reviews", "services"
+  add_foreign_key "reviews", "users", column: "client_id"
+  add_foreign_key "reviews", "users", column: "freelancer_id"
+  add_foreign_key "services", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,9 +11,6 @@ require 'faker'
     biography: Faker::Lorem.paragraph(sentence_count: 2),
     skills: Faker::Lorem.words(number: rand(1..5)),
     birthdate: Faker::Date.birthday(min_age: 18, max_age: 65),
-    address: Faker::Address.street_address,
-    city: Faker::Address.city,
-    country: Faker::Address.country,
     mobile: Faker::PhoneNumber.phone_number
   )
 end
@@ -26,12 +23,35 @@ end
     password: 'password123!',
     freelancer: false,
     client: true,
+    birthdate: Faker::Date.birthday(min_age: 18, max_age: 65),
+    mobile: Faker::PhoneNumber.phone_number
+  )
+end
+
+cities = [
+  'Mactan',
+  'Cebu',
+  'Makati',
+  'Makati',
+  'Manila', 
+  'Mandaluyong',
+  'Taguig',
+  'Davao'
+]
+
+cities.each do |city|
+  User.create!(
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    email: Faker::Internet.email,
+    password: 'password123!',
+    freelancer: true,
+    client: false,
     biography: Faker::Lorem.paragraph(sentence_count: 2),
     skills: Faker::Lorem.words(number: rand(1..5)),
     birthdate: Faker::Date.birthday(min_age: 18, max_age: 65),
-    address: Faker::Address.street_address,
-    city: Faker::Address.city,
-    country: Faker::Address.country,
+    city: city,
+    country: 'Philippines',
     mobile: Faker::PhoneNumber.phone_number
   )
 end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,34 +1,7 @@
-# spec/fixtures/users.yml
-valid_user:
-  email: valid_user@example.com
-  first_name: Valid
-  
-missing_first_name_user:
-  email: missing_firstname@example.com
-
-short_first_name_user:
-  email: short_firstname@example.com
-  first_name: S
-
-long_first_name_user:
-  email: long_firstname@example.com
-  first_name: Looooooooooooooooooooooooooooooooooooooooooooong
-  last_name: LongFirstName
-
-missing_last_name_user:
-  email: missing_lastname@example.com
-  first_name: MissingLastName
-
-short_last_name_user:
-  email: short_lastname@example.com
-  first_name: ShortLastName
-  last_name: S
-
-long_last_name_user:
-  email: long_lastname@example.com
-  first_name: LongLastName
-  last_name: Looooooooooooooooooooooooooooooooooooooooooooong
-
-invalid_email_user:
-  email: invalid_email_example.com
-  first_name: InvalidEmail
+valid_freelancer:
+  first_name: 'freelancer'
+  last_name: 'user'
+  email: freelancer@example.com
+  city: 'Makati'
+  country: 'Philippines'
+  freelancer: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,50 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'validations' do
-    let(:user_valid) { users(:valid_user) }
-    let(:user_missing_first_name) { users(:missing_first_name_user) }
-    let(:user_short_first_name) { users(:short_first_name_user) }
-    let(:user_long_first_name) { users(:long_first_name_user) }
-    let(:user_missing_last_name) { users(:missing_last_name_user) }
-    let(:user_short_last_name) { users(:short_last_name_user) }
-    let(:user_long_last_name) { users(:long_last_name_user) }
-    let(:user_invalid_email) { users(:invalid_email_user) }
+  let(:valid_freelancer) { users(:valid_freelancer) }
 
-    context 'when the user is valid' do
-      it 'is valid' do
-        expect(user_valid).to be_valid
-      end
+  context 'geocoding' do
+    it 'sets the address before validation' do
+      valid_freelancer.valid?
+      expect(valid_freelancer.address).to eq('Makati, Philippines')
     end
 
-    context 'when first name is invalid' do
-      it 'is invalid without a first name' do
-        expect(user_missing_first_name).to be_invalid
-      end
-
-      it 'is invalid with a short first name' do
-        expect(user_short_first_name).to be_invalid
-      end
-
-      it 'is invalid with a long first name' do
-        expect(user_long_first_name).to be_invalid
-      end
-    end
-
-    context 'when last name is invalid' do
-      it 'is invalid with a short last name' do
-        expect(user_short_last_name).to be_invalid
-      end
-
-      it 'is invalid with a long last name' do
-        expect(user_long_last_name).to be_invalid
-      end
-    end
-
-    context 'when the email is invalid' do
-      it 'is not a valid email' do
-        expect(user_invalid_email).to be_invalid
-      end
+    it 'geocodes the user after validation' do
+      valid_freelancer.save
+      expect(valid_freelancer.latitude).to be_present
+      expect(valid_freelancer.longitude).to be_present
     end
   end
 end


### PR DESCRIPTION
## Usage
Run `bundle` and `db:reset`

## Demo
```
# displays a list of users with geocoded addresses, these users will have a latitude and longitude attribute
User.geocoded

# displays a list of users near Cebu
User.near("Cebu")

# displays a list of users near Cebu, within 5 miles
User.near("Cebu", 5)
```

## PR Summary

**Implement geocoding to user model**
- Create a private method to set the user's address. For uniformity, user creation should include a `city` field and build the address from it. In the future, we can further specify the locations since Geocoder also supports barangays.
- Added attributes: `latitude` and `longitude` to the user model. These attributes are required by geocoder and will be automatically populated by geocoder if `city` and `country` are present.

**Update seeds file with user's with relevant addresses**
- Created 8 users with cities from the Philippines.
- Removed the address and city attributes from other generated users because the geocode api will get triggered when creating these users.