### PR TITLE
Add toast functionality

### DIFF
--- a/app/views/layouts/_toasts.html.erb
+++ b/app/views/layouts/_toasts.html.erb
@@ -1,0 +1,6 @@
+<% if notice %>
+  <%= render_toast id: 'default_toast', description: notice %>
+<% end %>
+<% if alert %>
+  <%= render_toast id: 'alert_toast', description: alert, variant: :destructive %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body class="max-w-7xl min-w-[350px] mx-auto flex h-full w-full min-h-screen flex-col bg-background text-foreground">
+    <%= turbo_frame_tag 'toasts' do %>
+      <%= render 'layouts/toasts' %>
+    <% end %>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## PR Summary
* Add toast partial in the application.html.erb
* Toasts will render from `:notice` or `:alert` flashes

## Usage
1. Triggering toast without redirect
```
respond_to do |format|
   flash.now[:notice] = 'toast text here'
end
```
2. Trigger toast after redirect
```
redirect_to root_path, flash[:notice] = 'toast text here'
```
3. Trigger alert toast (color red)
```
flash[:alert] = 'this will display a red toast'
```
