### PR TITLE
Add delete appointment functionality

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -40,7 +40,6 @@ class AppointmentsController < ApplicationController
     @service = Service.find(service_id)
   end
 
-
   def set_fees
     @price ||= @service.price
     @service_fee ||= @price * 0.025

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -7,7 +7,7 @@ class AppointmentsController < ApplicationController
   end
 
   def index
-    @appointments = Appointment.where(client_id: current_user.id)
+    @appointments = Appointment.where(client_id: current_user.id).or(Appointment.where(freelancer_id: current_user.id))
     authorize @appointments
   end
 
@@ -29,6 +29,7 @@ class AppointmentsController < ApplicationController
     service_id ||= params[:id] || params.dig(:appointment, :service_id)
     @service = Service.find(service_id)
   end
+
 
   def set_fees
     @price ||= @service.price

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,5 +1,6 @@
 class AppointmentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_appointment, only: %i[destroy]
   before_action :set_service, :set_fees, only: %i[new create]
 
   rescue_from Pundit::NotAuthorizedError do
@@ -23,7 +24,16 @@ class AppointmentsController < ApplicationController
     handle_appointment_save
   end
 
+  def destroy
+    authorize @appointment
+    handle_appointment_destroy
+  end
+
   private
+
+  def set_appointment
+    @appointment ||= Appointment.find(params[:id])
+  end
 
   def set_service
     service_id ||= params[:id] || params.dig(:appointment, :service_id)
@@ -46,6 +56,17 @@ class AppointmentsController < ApplicationController
         flash.now[:alert] = @appointment.errors.full_messages.first
         format.turbo_stream { render 'appointments/create_failure' }
       end
+    end
+  end
+
+  def handle_appointment_destroy
+    respond_to do |format|
+      if @appointment.destroy
+        flash.now[:notice] = "The appointment request for #{@appointment.freelancer.first_name}'s service was successfully deleted"
+      else
+        flash.now[:alert] = @appointment.errors.full_messages.to_sentence
+      end
+      format.turbo_stream { render 'appointments/delete', locals: { id: @appointment.id } }
     end
   end
 

--- a/app/helpers/components/button_helper.rb
+++ b/app/helpers/components/button_helper.rb
@@ -17,6 +17,6 @@ module Components::ButtonHelper
     button_classes = tw(button_classes)
     text = label if label.present?
     text = capture(&block) if block
-    render 'components/ui/button', text:, button_classes:, as:, href:, data:, **options
+    render 'components/ui/button', text:, button_classes:, as:, href:, data:, options: options
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -14,10 +14,9 @@ class Appointment < ApplicationRecord
 
   def set_price
     service = Service.find(service_id)
-    fee = service.price
-    price = fee * duration
+    price = service.price * duration
     service_fee = price * 0.025
-    fee = price + service_fee
+    self.fee = price + service_fee
   end
 
   def validate_deletion

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,6 +1,7 @@
 class Appointment < ApplicationRecord
   belongs_to :client, class_name: 'User', foreign_key: 'client_id'
   belongs_to :freelancer, class_name: 'User', foreign_key: 'freelancer_id'
+  belongs_to :service
 
   validates :description, :start, :end, :duration, :service_id, :client_id, :freelancer_id, presence: true
 
@@ -11,10 +12,11 @@ class Appointment < ApplicationRecord
   private
 
   def set_price
-    service = Service.find(self.service_id)
+    service = Service.find(service_id)
     fee = service.price
-    price = fee * self.duration
+    price = fee * duration
     service_fee = price * 0.025
-    self.fee = price + service_fee
+    fee = price + service_fee
   end
+
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -8,6 +8,7 @@ class Appointment < ApplicationRecord
   enum status: { pending: 0, accepted: 1, denied: 2, expired: 3, paid: 4, blocked: 5 }
 
   before_save :set_price
+  before_destroy :validate_deletion
 
   private
 
@@ -19,4 +20,13 @@ class Appointment < ApplicationRecord
     fee = price + service_fee
   end
 
+  def validate_deletion
+    if status != 'pending'
+      errors.add(:base, 'Appointment cannot be deleted unless it is pending')
+      throw(:abort)
+    elsif start < 3.days.from_now
+      errors.add(:base, 'Appointment cannot be deleted within three (3) days of the start date')
+      throw(:abort)
+    end
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,5 @@
 class Service < ApplicationRecord
   belongs_to :user
   has_many :reviews
+  has_many :appointments
 end

--- a/app/views/appointments/_form_delete.html.erb
+++ b/app/views/appointments/_form_delete.html.erb
@@ -1,0 +1,27 @@
+<%= render_dialog do %>
+  <%= dialog_trigger do %>
+    <span class='cursor-pointer text-muted-foreground hover:text-muted-foreground/90'>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+      </svg>
+    </span>
+  <% end %>
+  <%= dialog_content do %>
+    <%= render_form_for appointment,
+      url: appointment_path(appointment.id), 
+      method: :delete do |f| %>
+      <div class="flex flex-col space-y-2 text-center sm:text-left">
+        <h2 class="text-lg font-semibold">Are you absolutely sure?</h2>
+        <p class="text-sm text-muted-foreground">
+          This action cannot be undone. This will permanently delete the appointment request.
+        </p>
+      </div>
+      
+      <div class="flex w-full flex-row items-center justify-end gap-2 mt-4">
+        <% cannot_delete = appointment.status != 'pending' || appointment.start <= 3.days.from_now %>
+        <%= render_button "Cancel", variant: :outline, data: { action: "ui--dialog#close" } %>
+        <%= f.submit "Delete", variant: :destructive, disabled: cannot_delete %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/appointments/delete.turbo_stream.erb
+++ b/app/views/appointments/delete.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update 'toasts', partial: 'layouts/toasts' %>
+
+<% if @appointment.destroyed? %>
+  <%= turbo_stream.remove "appointment_#{id}" %>
+<% end %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -9,6 +9,7 @@
       <p><%= appointment.description %></p>
       <span><%= appointment.start %></span>
       <span><%= appointment.end %></span>
+      <span><%= appointment.fee %></span>
       <span><%= appointment.freelancer.first_name %></span>
 
       <% if current_user&.role&.name == 'client' %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -10,6 +10,12 @@
       <span><%= appointment.start %></span>
       <span><%= appointment.end %></span>
       <span><%= appointment.freelancer.first_name %></span>
+
+      <% if current_user&.role&.name == 'client' %>
+        <span class='absolute top-5 right-5'>
+          <%= render partial: 'form_delete', locals: { appointment: appointment } %>
+        </span>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,13 +1,15 @@
 <h1>Appointments</h1>
 
-<%= link_to 'Create Appointment', new_appointment_path %>
-<%= button_to 'Log Out', destroy_user_session_path, method: :delete %>
-
-<% @appointments.each do |appointment| %> 
-  <ul class='flex flex-col gap-2'>
-    <li><%= appointment.description %></li>
-    <li><%= appointment.start %></li>
-    <li><%= appointment.end %></li>
-    <li><%= appointment.freelancer.first_name %></li>
-  </ul>
-<% end %>
+<div class='h-fit w-full flex flex-col gap-4'>
+  <% @appointments.each do |appointment| %> 
+    <%= render_card class: 'relative flex flex-col', id: "appointment_#{appointment.id}" do %>
+      <span><%= appointment.status.capitalize %></span>
+      <h2 class='text-lg text-muted-foreground'><%= appointment.service.title %></h2>
+      <%= render_separator class: 'my-4' %>
+      <p><%= appointment.description %></p>
+      <span><%= appointment.start %></span>
+      <span><%= appointment.end %></span>
+      <span><%= appointment.freelancer.first_name %></span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/components/ui/_button.html.erb
+++ b/app/views/components/ui/_button.html.erb
@@ -1,11 +1,11 @@
 <!--prettier-ignore-->
 <% case as %>
 <% when :link %>
- <%= link_to href, class: button_classes, data: data do %>
+ <%= link_to href, class: button_classes, data: data, **options do %>
     <%= text %>
   <% end %>
 <% when :button %>
-  <%= button_tag class: button_classes, data: data do %>
+  <%= button_tag class: button_classes, data: data, **options do %>
     <%= text %>
   <% end %>
 <% end %>

--- a/app/views/components/ui/_card.html.erb
+++ b/app/views/components/ui/_card.html.erb
@@ -1,4 +1,4 @@
-<div class="h-full w-full min-w-[350px] p-6 overflow-hidden rounded-lg ring-1 ring-black/5 dark:ring-white/10 bg-card text-card-foreground shadow-sm <%= options[:class] %>">
+<div id="<%= options[:id] %>" class="h-full w-full min-w-[350px] p-6 overflow-hidden rounded-lg ring-1 ring-black/5 dark:ring-white/10 bg-card text-card-foreground shadow-sm <%= options[:class] %>">
   <% if title || subtitle %>
   <div class="flex flex-col space-y-2">
     <% if title %>

--- a/db/seeds/roles.rb
+++ b/db/seeds/roles.rb
@@ -6,7 +6,8 @@ Role.find_or_create_by!(name: 'freelancer') do |r|
     read_services: true,
     update_services: true,
     delete_services: true,
-    read_appointments: true
+    read_appointments: true,
+    update_appointments: true
   }
 end
 
@@ -19,6 +20,6 @@ Role.find_or_create_by!(name: 'client') do |r|
     create_appointments: true,
     read_appointments: true,
     update_appointments: true,
-    delete_appointments: false
+    delete_appointments: true
   }
 end


### PR DESCRIPTION
## Demo
![demo_appointment_delete](https://github.com/TyJacalan/booking-app/assets/143598524/58d70447-8168-42fa-83dd-16e617cde303)

## PR Summary

**All Users can view a list of their appointments**
- accessed through `/appointments`

**Clients can delete appointments**
- only clients will have an _X_ button
- appointments can only be deleted if they follow the ff. conditions:
   - `start` must not be within 3 days
   - `status` must be 'pending'
- In case of invalid destruction, (1) frontend validates by disabling delete button and (2) backend validates through the `validate_deletion` method

**Ui gets updated after deleting appointments**
- _Failure:_ alert toast is rendered
- _Success:_ notice toast is rendered, appointment item is deleted