### PR TITLE
Render toasts in pages where user layout is being used

### DIFF
--- a/app/views/layouts/user.html.erb
+++ b/app/views/layouts/user.html.erb
@@ -13,6 +13,8 @@
   </head>
 
   <body class="max-w-7xl min-w-[350px] mx-auto flex h-full w-full min-h-screen flex-col bg-background text-foreground">
+    <%= render 'layouts/toasts' %>
+
     <%= render 'layouts/user_nav' %>
     <%= yield %>
   </body>


### PR DESCRIPTION
## PR Summary
#### Render toasts layouts in `user.html.erb`
Toasts were not working for controller that user the _users_ layout. I noticed this for the appointment controller.