### PR TITLE
Implement avatar component

### DIFF
--- a/app/helpers/components/avatar_helper.rb
+++ b/app/helpers/components/avatar_helper.rb
@@ -3,6 +3,9 @@ module Components::AvatarHelper
     avatar_classes = 'relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full hover:shadow-lg'
     avatar_classes << " #{options[:class]}"
     avatar_classes = tw(avatar_classes)
-    render 'components/ui/avatar', avatar_classes:, src:, data:, **options
+
+    alt = options[:alt]
+    size = options[:size]
+    render 'components/ui/avatar', avatar_classes:, src:, alt:, size:, data:, **options
   end
 end

--- a/app/views/components/ui/_avatar.html.erb
+++ b/app/views/components/ui/_avatar.html.erb
@@ -1,13 +1,9 @@
 <div class="<%= avatar_classes %>" data=<%= data %>>
   <% if src %>
-    <%= image_tag src, class: "aspect-square h-full w-full" %>
+    <%= image_tag src, class: "aspect-square h-full w-full", alt: alt, size: size %>
   <% else %>
     <div class="flex h-full w-full items-center justify-center rounded-full bg-muted">
-      <% if current_user.first_name.blank? %>
-        <%= current_user.full_name&.chr&.upcase %>
-      <% else %>
-        <%= current_user.first_name&.chr&.upcase  %>
-      <% end %>
+      <%= image_tag 'default_avatar.jpg', alt: alt, size: size, class: 'rounded-full' %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -57,7 +57,7 @@
         <%= render_dropdown_menu do %>
           <%= dropdown_menu_trigger do %>
             <div class='p-2'>
-              <%= render_avatar src: current_user.avatar_url %>
+              <%= render_avatar src: current_user.avatar_url, alt: current_user.first_name %>
             </div>
           <% end %>
 

--- a/app/views/users/_freelancer.html.erb
+++ b/app/views/users/_freelancer.html.erb
@@ -1,11 +1,7 @@
 <div class="flex justify-between gap-4 p-10">
   <div class="flex flex-col gap-4 w-full sm:w-full lg:w-2/3">
     <div class="flex items-end gap-4 p-4">
-      <% if user.avatar_url.present? %>
-        <%= image_tag user.avatar_url, size: '70x70', class: 'rounded-full' %>
-      <% else %>
-        <%= image_tag 'default_avatar.jpg', alt: 'Default Avatar', size: '70x70', class: 'rounded-full' %>
-      <% end %>
+      <%= render_avatar src: current_user.avatar_url, alt: current_user.first_name, size: '70x70', class: 'h-fit w-fit' %>
       <div>
         <h3 class="text-4xl font-semibold px-4"><%= user.full_name.titleize %></h3>
         <span class="p-4 text-gray-500">

--- a/app/views/users/_freelancer_current.html.erb
+++ b/app/views/users/_freelancer_current.html.erb
@@ -1,11 +1,7 @@
 <div class="flex justify-between gap-4 p-10">
   <div class="flex flex-col gap-4 w-full sm:w-full lg:w-2/3">
     <div class="flex items-end gap-4 p-4">
-      <% if current_user.avatar_url.present? %>
-        <%= image_tag current_user.avatar_url, size: '70x70', class: 'rounded-full' %>
-      <% else %>
-        <%= image_tag 'default_avatar.jpg', alt: 'Default Avatar', size: '70x70', class: 'rounded-full' %>
-      <% end %>
+      <%= render_avatar src: current_user.avatar_url, alt: current_user.first_name, size: '70x70', class: 'h-fit w-fit' %>
       <div>
         <h3 class="text-4xl font-semibold px-4"><%= current_user.full_name.capitalize %></h3>
         <span class="p-4 text-gray-500">


### PR DESCRIPTION
## Usage
```
<%= render_avatar src: <url of the image> %>

# w/ alt and size
<%= render_avatar src: <url of image>, alt: <fallback text>, size: '70x70' %>
```
Note: you can pass in **class** to style the image container

## PR Summary

#### Utilize [avatar component](https://github.com/TyJacalan/booking-app/blob/main/app/views/components/ui/_avatar.html.erb) in instances where an avatar is being displayed
Used in the navbar, freelancer profiles (current and other), and appointment index. This allows for consistent styles throughout the application. The [default avatar image](https://github.com/TyJacalan/booking-app/blob/dev/app/assets/images/default_avatar.jpg) is set as the fallback if `avatar_url` is empty.

#### Modify avatar to accept `alt` and `size` attributes
Alt: content displayed if image fails to load
Size: modifies the size of the image. Note that it requires `class: h-fit w-fit` to be set since default container size is set to `h-8 w-8`