### PR TITLE
Fix routing issues (#59, #70, #73)

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CalendarsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @date = params[:date] ? Date.parse(params[:date]) : Date.today
     @appointments = Appointment.where(freelancer_id: current_user.id, start: @date.beginning_of_month.beginning_of_week..@date.end_of_month.end_of_week)

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,4 +1,6 @@
 class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @notifications = current_user.notifications.order(:created_at).page(params[:page]).per(20)
     authorize @notifications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   root 'services#index'
 
   resources :alerts, only: %i[index]
-  resources :appointments, except: %i[show edit]
+  resources :appointments, except: %i[show]
   resources :batch_update_notifications, only: [:update]
   resources :calendars, except: %i[new show edit update]
   resources :notifications, only: %i[index update]


### PR DESCRIPTION
## PR Summary

#### Remove exception for edit appointments path
Visiting the appointments index (Issue: #70) or getting redirected to the appointments index (Issue: #73) threw a no method error for the `edit_appointment_path`, which was added on PR: #49 to lazy load the edit appointment forms.

#### Add user authentication in controllers
Logging out from certain paths: notifications and calendars does not redirect to the authentication page (Issue: #59). Since these routes require variables from the `current_user`, adding 
```
before action :authenticate_user!
```
 is required to reroute to the authentication page after logging out. 