### PR TITLE
Add conditional rendering for role switch and freelance registration buttons (#71)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,10 @@ class User < ApplicationRecord
     end
   end
 
+  def registered_freelancer?
+    [biography, birthdate, skills, mobile, address].all?(&:present?)
+  end
+
   private
 
   def set_default_role

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -2,7 +2,6 @@
   <nav class='md:w-full hidden flex-col gap-6 text-lg font-medium md:flex md:flex-row md:items-center md:justify-between md:gap-4 md:text-sm lg:gap-6'>
     <span class='w-32'><%= link_to 'Booking App', root_path, class: 'hover:cursor-pointer' %></span>
     <div class='w-full flex flex-row justify-center gap-4 text-sm text-muted-foreground'>
-      <%# Add filters triggers here %>
       <%= link_to 'Profile', user_path(@user), class: 'hover:underline' if @user&.role&.name == 'freelancer' %>
       <%= link_to 'Services', user_services_path(@user), class: 'hover:underline' if @user&.role&.name == 'freelancer' %>
       <%= link_to 'Appointments', appointments_path, class: 'hover:underline' if @user == current_user %>
@@ -14,18 +13,17 @@
   <div class="w-full">
     <% if user_signed_in? %>
       <div class="flex w-full items-center justify-end gap-4  md:gap-2 lg:gap-4">
-        <%# Add Service %>
-        <div class="flex justify-center items-center">
-          <div class="rounded-lg hover:bg-gray-100 p-2 transition duration-300 ease-in-out">
-            <%= link_to policy(Service).new? ? new_service_path : new_freelancer_path, class: "font-semibold" do %>
-              <% if current_user&.role&.name == 'freelancer' %>
-                Offer your services
-              <% else %>
-                Become a freelancer  
-              <% end %>
+        <% unless current_user.registered_freelancer? %>
+          <%= render_button as: :link,
+            variant: :outline,
+            href: policy(Service).new? ? new_service_path : new_freelancer_path do %>
+            <% if current_user&.role&.name == 'freelancer' %>
+              Offer your services
+            <% else %>
+              Become a freelancer  
             <% end %>
-          </div>
-        </div>
+          <% end %>
+        <% end %>
 
         <%# mode toggle %>
         <%= render_dropdown_menu do %>
@@ -87,7 +85,7 @@
               <%= link_to 'My Appointments', appointments_path %>
             <% end %>
             <%= render_separator class: 'my-1' %>
-            <% if current_user&.role&.name == 'client' %>
+            <% if current_user&.role&.name == 'client' && current_user.registered_freelancer? %>
               <%= dropdown_menu_item do %>
                 <%= button_to 'Switch to freelancing', user_role_path(current_user.id, current_user.role.id), method: :patch %>
               <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,16 +13,18 @@
   <div class="w-full">
     <% if user_signed_in? %>
       <div class="flex w-full items-center justify-end gap-4  md:gap-2 lg:gap-4">
-        <% unless current_user.registered_freelancer? %>
-          <%= render_button as: :link,
+        <% if current_user&.registered_freelancer? && current_user&.role&.name == 'freelancer' %>
+          <%= render_button 'Offer your services',
+            as: :link,
             variant: :outline,
-            href: policy(Service).new? ? new_service_path : new_freelancer_path do %>
-            <% if current_user&.role&.name == 'freelancer' %>
-              Offer your services
-            <% else %>
-              Become a freelancer  
-            <% end %>
-          <% end %>
+            href: new_service_path %>
+        <% end %>
+
+        <% unless current_user&.registered_freelancer? %>
+          <%= render_button 'Become a freelancer',
+            as: :link,
+            variant: :outline,
+            href: new_freelancer_path %>
         <% end %>
 
         <%# mode toggle %>


### PR DESCRIPTION
## PR Summary

The following conditions are now applied when rendering the freelancer registration, service offering, and role switching buttons:
1. Freelancers will see the service offering and role switching buttons
2. Clients (unregistered freelancers) will see the freelancer registrations button
3. Clients (registered freelancers) will see the role switching button