### PR TITLE
Add appointments filtering and link calendar events to filtered appointments (#80)

### DIFF
--- a/app/components/shadcn/form_builder.rb
+++ b/app/components/shadcn/form_builder.rb
@@ -13,8 +13,8 @@ class Shadcn::FormBuilder < ActionView::Helpers::FormBuilder
 
   def text_field(method, options = {})
     error_class = @object&.errors&.[](method)&.any? ? 'error' : ''
-    name = object_name ? "#{object_name}[#{method}]" : method.to_s
-    id = object_name ? "#{object_name}_#{method}" : method.to_s
+    name = object_name && !options[:ransack] ? "#{object_name}[#{method}]" : method.to_s
+    id = object_name && !options[:ransack] ? "#{object_name}_#{method}" : method.to_s
     options[:class] = @template.tw("#{options[:class]} #{error_class}")
     value = @object&.send(method) || ''
 
@@ -100,8 +100,8 @@ class Shadcn::FormBuilder < ActionView::Helpers::FormBuilder
 
   def select_field(method, options = {}, &block)
     error_class = @object&.errors&.[](method)&.any? ? 'error' : ''
-    name = object_name ? "#{object_name}[#{method}]" : method.to_s
-    id = object_name ? "#{object_name}_#{method}" : method.to_s
+    name = object_name && !options[:ransack] ? "#{object_name}[#{method}]" : method.to_s
+    id = object_name && !options[:ransack] ? "#{object_name}_#{method}" : method.to_s
     options[:class] = @template.tw("#{options[:class]} #{error_class}")
 
     select_html = @template.render_select(

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -5,6 +5,7 @@ class AppointmentsController < ApplicationController
 
   def index
     @appointments = fetch_appointments
+    @statuses = Appointment.statuses.to_a
   end
 
   def new
@@ -51,6 +52,10 @@ class AppointmentsController < ApplicationController
   def fetch_appointments
     appointments = Appointments::FetchAppointments.call(current_user)
     authorize appointments
+
+    @q = Appointment.ransack(params[:q])
+    appointments = @q.result(distinct: true).where(id: appointments.pluck(:id))
+
     @appointments = Kaminari.paginate_array(appointments).page(params[:page]).per(5)
   end
 

--- a/app/helpers/components/calendar_helper.rb
+++ b/app/helpers/components/calendar_helper.rb
@@ -20,7 +20,7 @@ module Components::CalendarHelper
     events_for_day.map do |event|
       render_button(event.service.title,
                     as: :link,
-                    href: service_path(event.service.id),
+                    href: "appointments/?q%5Bid_eq%5D=#{event.service_id}",
                     class: 'h-fit w-full py-2 px-4 rounded-md bg-muted text-left truncate',
                     variant: :outline)
     end.join.html_safe

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -11,6 +11,14 @@ class Appointment < ApplicationRecord
   before_save :set_price
   before_update :validate_update
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[client_id freelancer_id service_id id status]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[client freelancer service]
+  end
+
   def total_hours
     ((self.end - start) / 3600).to_i
   end

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,6 +1,21 @@
 <div class='h-fit w-full flex flex-col gap-4 p-10'>
+  <%= render_form_for appointments_path, method: :get, class: 'flex flex-row gap-2', data: { controller: 'auto-submit' } do |f| %>
+    <%= f.select_field 'q[status_eq]',
+      class: 'w-48 text-muted-foreground cursor-pointer',
+      data: { action: 'change->auto-submit#submit' },
+      ransack: true do |select| %>
+      <%= select.option label: 'Filter by Status', value: nil %>
+      <% @statuses.each do |status| %>
+        <%= select.option label: status[0].capitalize, value: status[1] %>
+      <% end %>
+    <% end %>
+    <%= f.text_field 'q[service_title_or_client_full_name_or_freelancer_full_name_cont]',
+      placeholder: 'Search appointments...',
+      ransack: true %>
+    <%= f.submit 'Search' %>
+  <% end %>
   <% @appointments.each do |appointment| %> 
-    <%= render_card class: 'relative flex flex-col min-w-[450px]', id: "appointment_#{appointment.id}" do %>
+    <%= render_card class: 'flex-1 relative flex flex-col min-w-[450px]', id: "appointment_#{appointment.id}" do %>
       <%= render partial: 'appointment', locals: { appointment: appointment } %>
     <% end %>
   <% end %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,19 +1,22 @@
 <div class='h-fit w-full flex flex-col gap-4 p-10'>
-  <%= render_form_for appointments_path, method: :get, class: 'flex flex-row gap-2', data: { controller: 'auto-submit' } do |f| %>
-    <%= f.select_field 'q[status_eq]',
-      class: 'w-48 text-muted-foreground cursor-pointer',
-      data: { action: 'change->auto-submit#submit' },
-      ransack: true do |select| %>
-      <%= select.option label: 'Filter by Status', value: nil %>
-      <% @statuses.each do |status| %>
-        <%= select.option label: status[0].capitalize, value: status[1] %>
+  <div class='h-fit w-full flex flex-row gap-2'>
+    <%= render_form_for appointments_path, method: :get, class: 'flex-1 flex flex-row gap-2', data: { controller: 'auto-submit' } do |f| %>
+      <%= f.select_field 'q[status_eq]',
+        class: 'w-48 text-muted-foreground cursor-pointer',
+        data: { action: 'change->auto-submit#submit' },
+        ransack: true do |select| %>
+        <%= select.option label: 'Filter by Status', value: nil %>
+        <% @statuses.each do |status| %>
+          <%= select.option label: status[0].capitalize, value: status[1] %>
+        <% end %>
       <% end %>
+      <%= f.text_field 'q[service_title_or_client_full_name_or_freelancer_full_name_or_freelancer_city_cont]',
+        placeholder: 'Search appointments...',
+        ransack: true %>
+      <%= f.submit 'Search' %>
     <% end %>
-    <%= f.text_field 'q[service_title_or_client_full_name_or_freelancer_full_name_or_freelancer_city_cont]',
-      placeholder: 'Search appointments...',
-      ransack: true %>
-    <%= f.submit 'Search' %>
-  <% end %>
+    <%= render_button 'Clear', as: :link, href: appointments_path, variant: :outline %> 
+  </div>
   <% @appointments.each do |appointment| %> 
     <%= render_card class: 'flex-1 relative flex flex-col min-w-[450px]', id: "appointment_#{appointment.id}" do %>
       <%= render partial: 'appointment', locals: { appointment: appointment } %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -9,7 +9,7 @@
         <%= select.option label: status[0].capitalize, value: status[1] %>
       <% end %>
     <% end %>
-    <%= f.text_field 'q[service_title_or_client_full_name_or_freelancer_full_name_cont]',
+    <%= f.text_field 'q[service_title_or_client_full_name_or_freelancer_full_name_or_freelancer_city_cont]',
       placeholder: 'Search appointments...',
       ransack: true %>
     <%= f.submit 'Search' %>


### PR DESCRIPTION
## Demo
![demo_appointment_filters](https://github.com/TyJacalan/booking-app/assets/143598524/df44b883-0adf-4390-b762-6f9fbe876df3)

## PR Summary

### Implement Ransack on Appointments model
Users can search by freelancers (full name and city), clients (full name), service (title). Users can filter by status.

Note: filtering by status is auto-submitted 

### Modify form builder to mimic Ransack form builder
You can now pass an option `ransack: true`, which will change how the`name` and `id` attributes are built when using either the _text_field_ or _select field_. The default format builds the fields as `@object[method]` whereas Ransack requires the format `q[...]` (see [full documentation](https://activerecord-hackery.github.io/ransack/getting-started/search-matches/) for search matchers.

### Redirect calendar events to filtered appointments index
This addresses issue (#80) where calendar events redirected to the service page instead of the appointment details. This is accomplished by 1. Enabling appointment id as a ransackable attribute:
```
  def self.ransackable_attributes(_auth_object = nil)
    %w[client_id freelancer_id service_id id status]
  end
```
 and 2. hardcoding the ransack query to the appointments path when creating the service links on the [calendar_helper](app/helpers/components/calendar_helper.rb):
```
href: "appointments/?q%5Bid_eq%5D=#{event.service_id}",
```

