### PR TITLE
Create Roles on Application Initialization (#101)

### DIFF
--- a/app/controllers/users/roles_controller.rb
+++ b/app/controllers/users/roles_controller.rb
@@ -15,7 +15,7 @@ class Users::RolesController < ApplicationController
   private
 
   def toggle_role(user)
-    if user.role.name == 'freelancer'
+    if user.freelancer?
       Role.find_by(name: 'client')
     else
       Role.find_by(name: 'freelancer')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,10 @@
 class User < ApplicationRecord
-  has_many :appointments, dependent: :destroy
+  has_many :client_appointments, class_name: 'Appointment', foreign_key: 'client_id', dependent: :destroy
+  has_many :freelancer_appointments, class_name: 'Appointment', foreign_key: 'freelancer_id', dependent: :destroy
   has_many :blocked_dates, dependent: :destroy
-  has_many :categories, dependent: :destroy
   has_many :notifications, dependent: :destroy
-  has_many :reviews, dependent: :destroy
+  has_many :reviews, class_name: 'Review', foreign_key: 'client_id', dependent: :destroy
+  has_many :reviews, class_name: 'Review', foreign_key: 'freelancer_id', dependent: :destroy
   has_many :services, dependent: :destroy
 
   belongs_to :role

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,10 @@ class User < ApplicationRecord
     end
   end
 
+  def freelancer?
+    role&.name == 'freelancer'
+  end
+
   def registered_freelancer?
     [biography, birthdate, skills, mobile, address].all?(&:present?)
   end

--- a/app/services/appointments/fetch_appointments.rb
+++ b/app/services/appointments/fetch_appointments.rb
@@ -1,9 +1,11 @@
 module Appointments
   class FetchAppointments
     def self.call(user)
-      Appointment.where(client_id: user.id)
-                 .or(Appointment.where(freelancer_id: user.id))
-                 .order(:start)
+      if user.freelancer?
+        user.freelancer_appointments.order(:start)
+      else
+        user.client_appointments.order(:start)
+      end
     end
   end
 end

--- a/app/services/notifications/create_notification.rb
+++ b/app/services/notifications/create_notification.rb
@@ -10,7 +10,7 @@ module Notifications
     def self.notify_updated_appointment(appointment, user)
       content_for_client = "#{appointment.freelancer.full_name} #{appointment.status} your request."
       content_for_freelancer = "#{appointment.client.full_name} updated their request."
-      content = user.role.name == 'freelancer' ? content_for_client : content_for_freelancer
+      content = user.freelancer? ? content_for_client : content_for_freelancer
       create_notification(appointment.client, content)
     end
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
   <div class="w-full">
     <% if user_signed_in? %>
       <div class="flex w-full items-center justify-end gap-4  md:gap-2 lg:gap-4">
-        <% if current_user&.registered_freelancer? && current_user&.role&.name == 'freelancer' %>
+        <% if current_user&.registered_freelancer? && current_user&.freelancer? %>
           <%= render_button 'Offer your services',
             as: :link,
             variant: :outline,
@@ -76,7 +76,7 @@
             <%= dropdown_menu_item do %>
               <%= link_to current_user.role.name == 'client' ? 'Profile' : 'Dashboard', current_user.role.name == 'client' ? edit_user_registration_path : user_path(current_user) %>
             <% end %>
-            <% if current_user&.role&.name == 'freelancer' %>
+            <% if current_user&.freelancer? %>
               <%= dropdown_menu_item do %>
                 <%= link_to 'My Services', services_user_path(current_user) %>
               <% end %>
@@ -91,11 +91,11 @@
               <%= link_to 'My Appointments', appointments_path %>
             <% end %>
             <%= render_separator class: 'my-1' %>
-            <% if current_user&.role&.name == 'client' && current_user.registered_freelancer? %>
+            <% if !current_user&.freelancer? && current_user.registered_freelancer? %>
               <%= dropdown_menu_item do %>
                 <%= button_to 'Switch to freelancing', user_role_path(current_user.id, current_user.role.id), method: :patch %>
               <% end %>
-            <% elsif current_user&.role&.name == 'freelancer' %>
+            <% elsif current_user&.freelancer? %>
               <%= dropdown_menu_item do %>
                 <%= button_to 'Switch to client', user_role_path(current_user.id, current_user.role.id), method: :patch %>
               <% end %>

--- a/app/views/layouts/_user_nav.html.erb
+++ b/app/views/layouts/_user_nav.html.erb
@@ -3,8 +3,8 @@
     <span class='w-32'><%= link_to 'Booking App', root_path, class: 'hover:cursor-pointer' %></span>
     <div class='w-full flex flex-row justify-center gap-4 text-sm text-muted-foreground'>
       <%# Add filters triggers here %>
-        <%= link_to 'Profile', user_path(current_user), class: 'hover:underline' if @user&.role&.name == 'freelancer' %>
-        <%= link_to 'Services', services_path, class: 'hover:underline' if @user&.role&.name == 'freelancer' %>
+        <%= link_to 'Profile', user_path(current_user), class: 'hover:underline' if @user&.freelancer? %>
+        <%= link_to 'Services', services_path, class: 'hover:underline' if @user&.freelancer? %>
         <%= link_to 'Appointments', appointments_path, class: 'hover:underline' if current_user == current_user %>
         <%= link_to 'Reviews', user_reviews_path(current_user) if user_signed_in? %>
         <%= link_to 'Calendar' if user_signed_in? %>
@@ -58,7 +58,7 @@
             <%= dropdown_menu_item do %>
               <%= link_to current_user.role.name == 'client' ? 'Profile' : 'Dashboard', current_user.role.name == 'client' ? edit_user_registration_path : user_path(current_user) %>
             <% end %>
-            <% if current_user&.role&.name == 'freelancer' %>
+            <% if current_user&.freelancer? %>
               <%= dropdown_menu_item do %>
                 <%= link_to 'My Services', services_path %>
               <% end %>

--- a/config/initializers/roles.rb
+++ b/config/initializers/roles.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+Role.find_or_create_by!(name: 'freelancer') do |r|
+  r.permissions = {
+    create_appointments: false,
+    create_services: true,
+    create_blocked_dates: true,
+    delete_appointments: false,
+    delete_blocked_dates: true,
+    delete_services: true,
+    read_appointments: true,
+    read_blocked_dates: true,
+    read_notifications: true,
+    read_services: true,
+    update_appointments: true,
+    update_notifications: true,
+    update_roles: true,
+    update_services: true
+  }
+end
+
+Role.find_or_create_by!(name: 'client') do |r|
+  r.permissions = {
+    create_appointments: true,
+    create_services: false,
+    create_blocked_dates: false,
+    delete_appointments: true,
+    delete_blocked_dates: false,
+    delete_services: false,
+    read_appointments: true,
+    read_blocked_dates: true,
+    read_notifications: true,
+    read_services: true,
+    update_appointments: true,
+    update_notifications: true,
+    update_roles: true,
+    update_services: false
+  }
+end


### PR DESCRIPTION
## PR Summary
Set client and freelancer roles on application mount. This is a potential fix for Issue: #101, since user creation runs `before_validation :set_default_role, on: :create` and likely causes an error since the roles do not exist on production yet. 