### PR TITLE
Second attempt at creating roles on application setup (#101)

### DIFF
--- a/db/migrate/20240606122636_create_freelancer_role.rb
+++ b/db/migrate/20240606122636_create_freelancer_role.rb
@@ -1,0 +1,26 @@
+class CreateFreelancerRole < ActiveRecord::Migration[7.1]
+  def up
+    Role.find_or_create_by!(name: 'freelancer') do |r|
+      r.permissions = {
+        create_appointments: false,
+        create_services: true,
+        create_blocked_dates: true,
+        delete_appointments: false,
+        delete_blocked_dates: true,
+        delete_services: true,
+        read_appointments: true,
+        read_blocked_dates: true,
+        read_notifications: true,
+        read_services: true,
+        update_appointments: true,
+        update_notifications: true,
+        update_roles: true,
+        update_services: true
+      }
+    end
+  end
+
+  def down
+    Role.find_by(name: 'freelancer')&.destroy
+  end
+end

--- a/db/migrate/20240606122646_create_client_role.rb
+++ b/db/migrate/20240606122646_create_client_role.rb
@@ -1,0 +1,26 @@
+class CreateClientRole < ActiveRecord::Migration[7.1]
+  def up
+    Role.find_or_create_by!(name: 'client') do |r|
+      r.permissions = {
+        create_appointments: true,
+        create_services: false,
+        create_blocked_dates: false,
+        delete_appointments: true,
+        delete_blocked_dates: false,
+        delete_services: false,
+        read_appointments: true,
+        read_blocked_dates: true,
+        read_notifications: true,
+        read_services: true,
+        update_appointments: true,
+        update_notifications: true,
+        update_roles: true,
+        update_services: false
+      }
+    end
+  end
+
+  def down
+    Role.find_by(name: 'client')&.destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_30_113922) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_122646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,12 +34,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_113922) do
     t.index ["service_id"], name: "index_appointments_on_service_id"
   end
 
-  create_table 'blocked_dates', force: :cascade do |t|
-    t.date 'date', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.bigint 'user_id', null: false
-    t.index ['user_id'], name: 'index_blocked_dates_on_user_id'
+  create_table "blocked_dates", force: :cascade do |t|
+    t.date "date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_blocked_dates_on_user_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -48,11 +48,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_113922) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-  
-  create_table 'categories_services', id: false, force: :cascade do |t|
-    t.bigint 'service_id', null: false
-    t.bigint 'category_id', null: false
-    t.index ['service_id', 'category_id'], name: 'index_categories_services_on_service_id_and_category_id'
+
+  create_table "categories_services", id: false, force: :cascade do |t|
+    t.bigint "service_id", null: false
+    t.bigint "category_id", null: false
+    t.index ["service_id", "category_id"], name: "index_categories_services_on_service_id_and_category_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -168,7 +168,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_113922) do
   add_foreign_key "appointments", "services"
   add_foreign_key "appointments", "users", column: "client_id"
   add_foreign_key "appointments", "users", column: "freelancer_id"
-  add_foreign_key 'blocked_dates', 'users'
+  add_foreign_key "blocked_dates", "users"
   add_foreign_key "comments", "appointments"
   add_foreign_key "comments", "reviews"
   add_foreign_key "comments", "users", column: "client_id"


### PR DESCRIPTION
## PR Summary
#### Create migration files that creates the freelancer and client role that runs on application initialization. 

As documented in Issue: #101 the roles are required for user sign in. 

Note that the first attempt (#103) failed because the initializer for roles was running before the `Role` model was initialized. I tested this branch on production and I was able to register an account.