### PR TITLE
Fix issues with appointments (#129)

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -13,7 +13,6 @@ class Appointment < ApplicationRecord
 
   before_destroy :validate_deletion
   before_save :set_price
-  before_update :validate_update
 
   after_update :send_review_notification, if: :is_completed_changed_to_true?
 
@@ -40,14 +39,6 @@ class Appointment < ApplicationRecord
     price = service.price * duration
     service_fee = price * 0.025
     self.fee = price + service_fee
-  end
-
-  def validate_update
-    return if status == 'accepted'
-    return unless start < 1.days.from_now
-
-    errors.add(:base, 'Appointment cannot be edited within one (1) day of the start date')
-    throw(:abort)
   end
 
   def validate_deletion

--- a/app/services/appointments/fetch_appointments.rb
+++ b/app/services/appointments/fetch_appointments.rb
@@ -3,9 +3,13 @@
 module Appointments
   class FetchAppointments
     def self.call(user)
-      Appointment.where(client_id: user.id)
-                 .or(Appointment.where(freelancer_id: user.id))
-                 .order(:start)
+      if user.freelancer?
+        Appointment.where(freelancer_id: user.id)
+                   .order(:start)
+      else
+        Appointment.where(client_id: user.id)
+                   .order(:start)
+      end
     end
   end
 end

--- a/app/views/appointments/_appointment.html.erb
+++ b/app/views/appointments/_appointment.html.erb
@@ -3,7 +3,7 @@
   <div class="flex flex-row gap-2 items-center mb-4">
     <% if role == 'client' %> 
       <span class="text-blue-500 font-semibold"><%= appointment.status.capitalize %></span>
-    <% elsif role == 'freelancer' %>
+    <% elsif role == 'freelancer' && current_user != appointment.client %>
       <%= render partial: 'form_edit_status', locals: { appointment: appointment } %>
     <% end %>
     <%= link_to appointment.service.title, service_path(appointment.service.id), class: 'text-lg text-gray-600' %>

--- a/app/views/appointments/_form_edit.html.erb
+++ b/app/views/appointments/_form_edit.html.erb
@@ -15,30 +15,7 @@
         method: :put,
         class: 'flex flex-col gap-4' do |f| %>
         <%= f.label :description %>
-        <%= f.text_area :description do %><%= appointment.description.gsub(/\s+/,'') %> <% end %>
-
-        <div class='flex flex-row gap-2'>
-          <div class='w-full flex flex-col gap-4'>
-            <%= f.label 'date_range', name: "appointment_date_range_#{appointment.id}" %>
-            <%= render_input name: 'date_range', 
-              id: "appointment_date_range_#{appointment.id}",
-              placeholder: appointment.start.strftime('%Y / %m / %d'), 
-              value: appointment.start,
-              autocomplete: false,
-              data: { appointment_target: 'dateInput' } %>
-          </div>
-
-          <div class='w-24 flex flex-col gap-4'>
-            <%= f.label :duration %>
-            <%= f.select_field :duration, 
-              selected: appointment.duration,
-              data: { appointment_target: 'durationInput' } do |select| %>
-              <% appointment.total_hours.times do |i| %>
-                <%= select.option label: i + 1, value: i + 1 %>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
+        <%= f.text_area :description do %><%= appointment.description %> <% end %>
         <%= f.submit 'Update' %>
       <% end %>
     </div>

--- a/app/views/appointments/_form_edit_status.html.erb
+++ b/app/views/appointments/_form_edit_status.html.erb
@@ -8,9 +8,9 @@
     <% end %>
   <% else %>
     <%= f.select_field :status, selected: appointment.status, disabled: 'pending', id: "status_form_#{appointment.id}", class: 'w-full', data: { action: 'change->auto-submit#submit' } do |select| %>
-      <%= select.option label: 'Pending', value: :pending %>
-      <%= select.option label: 'Accept', value: :accepted %>
-      <%= select.option label: 'Reject', value: :rejected %>
+      <%= select.option label: 'Pending', value: 'pending' %>
+      <%= select.option label: 'Accept', value: 'accepted' %>
+      <%= select.option label: 'Reject', value: 'rejected' %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## PR Summary
### Render appointments based on roles and user
Address issue #129, in two ways: (1) only render appointments based on the current role (i.e. the query to fetching appointments when logged in as a client is different when logged in as a freelancer)
```
if user.freelancer?
 Appointment.where(freelancer_id: user.id)
            .order(:start)
else
 Appointment.where(client_id: user.id)
            .order(:start)
end
```
and (2) add a condition to display the form only if the client is not equal to the current user.
```
<% elsif role == 'freelancer' && current_user != appointment.client %>
```

### Fix issue where select form was not rendering the correct value
The selected value could not find a matching option because the values were set as symbols. Set values as strings instead.

```
<%= select.option label: 'Pending', value: 'pending' %>
# instead of
<%= select.option label: 'Pending', value: :pending %>
```

### Fix issue where appointment could not be changed from accepted to completed 
Updating status would conflict with the date (can only be updated if start date is greater than 1 day from current date). This validation was removed entirely since the status should be changed from 'accepted' -> 'completed', ideally after the appointment has ended. 

To supplement removing this validation, uses can no longer update the date and duration of an appointment since doing so will cause price changes and the payment process will be nullified.